### PR TITLE
Fix audio file error handling

### DIFF
--- a/Source/AudioFileReader.cpp
+++ b/Source/AudioFileReader.cpp
@@ -4,6 +4,7 @@
 #include <iostream>
 #include <fstream>
 #include <vector>
+#include <stdexcept>
 
 // Lê os metadados do arquivo e inicializa as variáveis da classe
 void AudioFileReader::readAudioMetadata() {
@@ -12,9 +13,9 @@ void AudioFileReader::readAudioMetadata() {
 
     SNDFILE* file = sf_open(filePath.c_str(), SFM_READ, &sfinfo);
     if (!file) {
-        std::cerr << "Failed to open audio file: " << sf_strerror(file) << std::endl;
-        std::cerr << "File path: " << filePath << std::endl;
-        exit(1);
+        std::string err = std::string("Failed to open audio file: ") + sf_strerror(file) +
+                          "\nFile path: " + filePath;
+        throw std::runtime_error(err);
     }
 
     // Exibir informações para debug

--- a/Source/Host.cpp
+++ b/Source/Host.cpp
@@ -27,7 +27,14 @@ bool Host::processAudioFile(const std::string& pluginPath,
     host.printParameterProperties();
     
     // Cria o leitor de áudio e obtém a taxa de amostragem
-    AudioFileReader audioReader(inputFilePath);
+    AudioFileReader* audioReaderPtr = nullptr;
+    try {
+        audioReaderPtr = new AudioFileReader(inputFilePath);
+    } catch (const std::exception& e) {
+        std::cerr << e.what() << std::endl;
+        return false;
+    }
+    AudioFileReader& audioReader = *audioReaderPtr;
     const int sampleRate = audioReader.getSampleRate();
 
     // Inicializa o host e seta os parâmetros
@@ -134,6 +141,7 @@ bool Host::processAudioFile(const std::string& pluginPath,
     delete[] audioForProcess[1];
     delete[] processedAudio[0];
     delete[] processedAudio[1];
+    delete audioReaderPtr;
 
     return saved;
 }


### PR DESCRIPTION
## Summary
- throw runtime error when failing to open audio files
- handle that exception in `Host` and clean up the `AudioFileReader` object

## Testing
- `cmake -S . -B build` *(fails: external/Crow missing)*

------
https://chatgpt.com/codex/tasks/task_e_6841aecea3d0833198d60e19503a59b1